### PR TITLE
Docs: kernel + adding tools + new-tool scaffolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # One Hundred SaaS (100saas)
 
-This repo is the public monorepo for the **100saas tool suite**
+This repo is the public monorepo for the **100saas tool suite**.
 
 ## What this is
 
@@ -13,6 +13,13 @@ This repo is the public monorepo for the **100saas tool suite**
 - `kernel/` — shared code used by many tools.
 - `tools/<toolSlug>/` — each tool lives in its own folder.
   - Today, the default backend for tools is **PocketBase** (see below).
+
+## Where to start
+
+- Run a tool locally: `docs/SELF_HOST.md`
+- How we work in GitHub: `docs/GOVERNANCE.md`
+- Shared backend kernel: `docs/KERNEL.md`
+- Adding a new tool: `docs/ADDING_A_TOOL.md`
 
 ## Why PocketBase (for now)
 

--- a/docs/ADDING_A_TOOL.md
+++ b/docs/ADDING_A_TOOL.md
@@ -1,0 +1,47 @@
+# Adding a tool
+
+This repo is a monorepo. Each tool lives in its own folder under `tools/<toolSlug>/`.
+
+## Before you code
+
+1) Propose the tool in Discussions:
+   - `https://github.com/100saas/One-Hundred-SaaS/discussions/1`
+2) Include:
+   - What problem it solves
+   - Who it’s for
+   - The workflow (3–7 steps)
+   - Any existing SaaS you’re replacing
+
+When it’s clear + scoped, open an Issue.
+
+## Create the folder
+
+Use the scaffolder:
+
+```bash
+node scripts/new_tool.mjs my-tool-slug --title "My Tool" --summary "1 sentence"
+```
+
+This creates:
+- `tools/<slug>/README.md` (high-level tool readme)
+- `tools/<slug>/pocketbase/SCHEMA.md` (schema + API rules notes)
+- `tools/<slug>/pocketbase/pb_hooks/main.pb.js` (hooks entrypoint)
+- `tools/<slug>/pocketbase/pb_migrations/0001_init_schema.js` (starter migration)
+
+## Test locally
+
+```bash
+node scripts/pb/run.mjs my-tool-slug --port 8090
+```
+
+Create an admin user, then verify:
+- hooks load without errors
+- migrations apply (via admin UI or CLI)
+- endpoints return `4xx/503` instead of `500` on invalid input
+
+## Submit a PR
+
+- Keep it small (one tool, or one kernel change).
+- Link the Issue/Discussion.
+- Do not commit secrets.
+

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -1,0 +1,37 @@
+# Kernel (shared backend logic)
+
+The kernel is shared backend code that multiple tools reuse to avoid re‑implementing the same auth/billing/invites/webhook plumbing.
+
+Today it ships as a PocketBase JS hooks module:
+
+- Source: `kernel/pocketbase/_shared/pb_hooks/_shared/kernel.js`
+
+## How tools use it
+
+Each tool’s PocketBase hooks (`tools/<slug>/pocketbase/pb_hooks/main.pb.js`) can `require()` the kernel and delegate endpoints to it:
+
+```js
+const k = require(__hooks + "/_shared/kernel.js");
+return k.handleInviteCreate(c, { toolSlug: "recover" });
+```
+
+## Local testing
+
+Use the local runner:
+
+```bash
+node scripts/pb/run.mjs recover
+```
+
+It assembles a local runtime folder under `.runtime/<toolSlug>/` and copies the kernel into:
+
+- `.runtime/<toolSlug>/pb_hooks/_shared/kernel.js`
+
+So `require(__hooks + "/_shared/kernel.js")` works exactly like production.
+
+## Design rules (to keep the kernel sane)
+
+- **Backwards compatible** by default: tools shouldn’t break when kernel changes.
+- **Safe by default**: if an integration key isn’t set, return a non‑fatal `503 <service>_not_configured`.
+- **Tool isolation**: any cross‑tool behavior must be explicit and documented.
+

--- a/scripts/new_tool.mjs
+++ b/scripts/new_tool.mjs
@@ -1,0 +1,170 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+function parseArgs(argv) {
+  const args = { _: [] }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--title') args.title = String(argv[++i] || '')
+    else if (a === '--summary') args.summary = String(argv[++i] || '')
+    else if (a === '--help' || a === '-h') args.help = true
+    else args._.push(a)
+  }
+  return args
+}
+
+function usage() {
+  return `Usage:
+  node scripts/new_tool.mjs <toolSlug> --title "Tool Name" --summary "1 sentence"
+
+Example:
+  node scripts/new_tool.mjs keyword-tracker --title "Keyword Tracker" --summary "Track rankings over time."
+`
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function normalizeSlug(s) {
+  return String(s || '')
+    .trim()
+    .toLowerCase()
+    .replaceAll('_', '-')
+    .replaceAll(' ', '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+async function exists(p) {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function mkdirp(p) {
+  await fs.mkdir(p, { recursive: true })
+}
+
+async function writeFileIfMissing(p, contents) {
+  if (await exists(p)) return false
+  await fs.writeFile(p, contents, 'utf8')
+  return true
+}
+
+function toolReadme({ slug, title, summary }) {
+  return `# ${title}
+
+${summary}
+
+## What’s in here
+
+- PocketBase backend: \`tools/${slug}/pocketbase/\`
+- Shared kernel (PocketBase): \`kernel/pocketbase/_shared/pb_hooks/_shared/kernel.js\`
+
+## Run locally
+
+\`\`\`bash
+node scripts/pb/run.mjs ${slug}
+\`\`\`
+`
+}
+
+function pbReadme({ title }) {
+  return `# ${title} — PocketBase instance
+
+This folder contains the PocketBase backend for this tool:
+
+- Hooks: \`pb_hooks/main.pb.js\`
+- Schema + rules notes: \`SCHEMA.md\`
+
+Integrations should be optional: if a key is missing, return \`503 <service>_not_configured\` instead of crashing.
+`
+}
+
+function schemaMd({ title }) {
+  return `# ${title} — PocketBase schema
+
+Define:
+- Collections
+- Fields
+- API Rules (tenant isolation, roles, public endpoints if any)
+
+Start small and iterate.
+`
+}
+
+function hooksStub({ slug }) {
+  return `// ${slug} hooks (PocketBase JS runtime)
+//
+// This is a stub. Add tool-specific routes, and reuse the shared kernel when possible.
+
+routerAdd("GET", "/api/health", (c) => {
+  return c.json(200, { ok: true, tool: "${slug}" });
+});
+
+// Example: use the shared kernel (copied into pb_hooks/_shared/kernel.js by scripts/pb/run.mjs)
+// const k = require(__hooks + "/_shared/kernel.js");
+// routerAdd("POST", "/api/invites/create", (c) => k.handleInviteCreate(c, { toolSlug: "${slug}" }));
+`
+}
+
+function migrationStub() {
+  return `/// <reference path="../pb_migrations/types.d.ts" />
+
+migrate((db) => {
+  // TODO: define collections for this tool.
+  // This is intentionally empty so you can start with SCHEMA.md and iterate.
+}, (db) => {
+  // TODO: rollback
+})
+`
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) {
+    console.log(usage())
+    process.exit(0)
+  }
+
+  const slug = normalizeSlug(args._[0])
+  const title = String(args.title || '').trim()
+  const summary = String(args.summary || '').trim()
+
+  assert(slug, `Missing toolSlug\n\n${usage()}`)
+  assert(title, `Missing --title\n\n${usage()}`)
+  assert(summary, `Missing --summary\n\n${usage()}`)
+
+  const repoRoot = process.cwd()
+  const toolsDir = path.join(repoRoot, 'tools')
+  const toolDir = path.join(toolsDir, slug)
+
+  assert(await exists(toolsDir), `Missing tools directory: ${toolsDir}`)
+  if (await exists(toolDir)) throw new Error(`Tool already exists: tools/${slug}`)
+
+  const pbDir = path.join(toolDir, 'pocketbase')
+  const pbHooksDir = path.join(pbDir, 'pb_hooks')
+  const pbMigrationsDir = path.join(pbDir, 'pb_migrations')
+
+  await mkdirp(pbHooksDir)
+  await mkdirp(pbMigrationsDir)
+
+  await writeFileIfMissing(path.join(toolDir, 'README.md'), toolReadme({ slug, title, summary }))
+  await writeFileIfMissing(path.join(pbDir, 'README.md'), pbReadme({ title }))
+  await writeFileIfMissing(path.join(pbDir, 'SCHEMA.md'), schemaMd({ title }))
+  await writeFileIfMissing(path.join(pbHooksDir, 'main.pb.js'), hooksStub({ slug }))
+  await writeFileIfMissing(path.join(pbMigrationsDir, '0001_init_schema.js'), migrationStub())
+
+  console.log(`created tools/${slug}`)
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err))
+  process.exit(1)
+})
+


### PR DESCRIPTION
Build-first improvements for contributors:

- `docs/KERNEL.md`: how tools reuse shared backend logic
- `docs/ADDING_A_TOOL.md`: step-by-step for adding tool #51+
- `scripts/new_tool.mjs`: scaffolds a new tool folder with PocketBase-first structure
- README updated with “where to start” links
- `scripts/setup_labels.mjs` now optionally creates `tool:<slug>` labels when `INCLUDE_TOOL_LABELS=1`
