### PR TITLE
Repo: triage/maintainers docs + community labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repo is the public monorepo for the **100saas tool suite**.
 - Adding a new tool: `docs/ADDING_A_TOOL.md`
 - Roadmap: `docs/ROADMAP.md`
 - FAQ: `docs/FAQ.md`
+- Maintainers/triage: `docs/TRIAGE.md`
 
 ## Why PocketBase (for now)
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -36,3 +36,8 @@ Keep it simple; don’t add custom fields until you need them.
 
 Current project:
 - `https://github.com/orgs/100saas/projects/1`
+
+## Maintainers
+
+- Maintainer expectations: `docs/MAINTAINERS.md`
+- Triage process: `docs/TRIAGE.md`

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -1,0 +1,26 @@
+# Maintainers
+
+This doc defines what maintainers do so contributors know what to expect.
+
+## Responsibilities
+
+- Keep contributions safe (no secrets, no private data).
+- Keep PRs small and reviewable.
+- Keep docs up to date as workflows evolve.
+- Keep the label system and project board usable.
+
+## Review expectations
+
+- We prefer many small PRs over one huge PR.
+- If a PR changes the kernel, ask for:
+  - backwards compatibility
+  - safe failure modes (`503 <service>_not_configured`)
+  - quick local testing notes
+
+## When maintainers can say “no”
+
+We’ll close or decline work that:
+- introduces lock-in traps
+- adds major dependencies without justification
+- adds an integration that can’t be self-hosted reasonably
+

--- a/docs/TRIAGE.md
+++ b/docs/TRIAGE.md
@@ -1,0 +1,33 @@
+# Triage (maintainers)
+
+This is a lightweight process for keeping the repo clean and contributor-friendly.
+
+## New Issues
+
+1) Add `status:triage`
+2) Add a `type:*` label
+3) Add `tool:<slug>` (or propose a new tool)
+4) Add `priority:p0|p1|p2`
+
+If it’s unclear, ask for:
+- expected workflow (3–7 steps)
+- sample data
+- success criteria (“done means…”)
+
+## Good first issues
+
+Use `good first issue` for:
+- doc improvements
+- small endpoint hardening (4xx/503 instead of 500)
+- tests/verification improvements (no new deps)
+- small schema/rules fixes
+
+Keep the scope to < 1 hour.
+
+## Security
+
+If it smells like a security issue:
+- do not ask for exploit details in public
+- point them to `SECURITY.md`
+- label `type:security`
+

--- a/scripts/labels.json
+++ b/scripts/labels.json
@@ -3,6 +3,7 @@
   { "name": "type:feature", "color": "a2eeef", "description": "New feature" },
   { "name": "type:chore", "color": "cfd3d7", "description": "Refactor / housekeeping" },
   { "name": "type:security", "color": "b60205", "description": "Security-related change" },
+  { "name": "type:docs", "color": "0075ca", "description": "Documentation change" },
 
   { "name": "priority:p0", "color": "b60205", "description": "Drop everything" },
   { "name": "priority:p1", "color": "d93f0b", "description": "High priority" },
@@ -12,6 +13,8 @@
   { "name": "status:ready", "color": "0e8a16", "description": "Ready to start" },
   { "name": "status:in-progress", "color": "1d76db", "description": "In progress" },
   { "name": "status:blocked", "color": "5319e7", "description": "Blocked" },
-  { "name": "status:shipped", "color": "0e8a16", "description": "Shipped" }
-]
+  { "name": "status:shipped", "color": "0e8a16", "description": "Shipped" },
 
+  { "name": "good first issue", "color": "7057ff", "description": "Good first contribution" },
+  { "name": "help wanted", "color": "008672", "description": "Extra attention needed" }
+]

--- a/scripts/verify_repo.mjs
+++ b/scripts/verify_repo.mjs
@@ -14,6 +14,9 @@ const forbiddenPatterns = [
   /BEGIN (RSA|EC|OPENSSH|DSA) PRIVATE KEY/,
   /-----BEGIN PRIVATE KEY-----/,
   /AKIA[0-9A-Z]{16}/, // common AWS access key prefix
+  /AIzaSy[0-9A-Za-z_-]{20,}/, // common Google API key prefix
+  /xox[baprs]-[0-9A-Za-z-]{10,}/, // common Slack token prefixes
+  /-----BEGIN CERTIFICATE-----/,
 ]
 
 async function listFiles(dir) {


### PR DESCRIPTION
Adds contributor-facing maintainer/triage docs and expands the starter label set:

- Adds `docs/TRIAGE.md` (how we label/triage issues, good first issues)
- Adds `docs/MAINTAINERS.md` (review expectations and maintainer responsibilities)
- Updates `docs/GOVERNANCE.md` + README with these links
- Adds labels: `type:docs`, `good first issue`, `help wanted`
- Strengthens secret-scan patterns in `scripts/verify_repo.mjs`
