### PR TITLE
Meta: contributing polish + tool request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "What should we build next?"
+    url: "https://github.com/100saas/One-Hundred-SaaS/discussions/1"
+    about: "Ideas, requests, and prioritization"
+  - name: "How to contribute"
+    url: "https://github.com/100saas/One-Hundred-SaaS/discussions/7"
+    about: "Start here for first contributions"
+  - name: "Tool request template"
+    url: "https://github.com/100saas/One-Hundred-SaaS/discussions/8"
+    about: "Use this format to propose a new tool"
+

--- a/.github/ISSUE_TEMPLATE/tool_request.yml
+++ b/.github/ISSUE_TEMPLATE/tool_request.yml
@@ -1,0 +1,59 @@
+name: Tool request
+description: Propose a new tool to add to the suite
+title: "[tool request]: "
+labels:
+  - "type:feature"
+  - "status:triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before you file this, please consider posting to Discussions first:
+        - https://github.com/100saas/One-Hundred-SaaS/discussions/1
+        - Template: https://github.com/100saas/One-Hundred-SaaS/discussions/8
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What pain are you trying to solve?
+      placeholder: "I need to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: who
+    attributes:
+      label: Who it's for
+      description: Role + company size + context
+      placeholder: "Solo founder / small SaaS / agency..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow (3–7 steps)
+      description: Describe the end-to-end flow the tool should support.
+      placeholder: |
+        1) ...
+        2) ...
+        3) ...
+    validations:
+      required: true
+
+  - type: input
+    id: competitor
+    attributes:
+      label: Existing SaaS you're replacing (optional)
+      description: Link a competitor if you have one.
+      placeholder: "https://..."
+
+  - type: textarea
+    id: done
+    attributes:
+      label: What does “done” look like?
+      placeholder: "If the tool can do X/Y/Z..."
+    validations:
+      required: true
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@
 - [ ] Edge cases + abuse cases considered
 - [ ] No secrets committed
 - [ ] UI changes include screenshots (if applicable)
-
+- [ ] If this adds a tool: docs updated (`tools/<slug>/README.md`, schema notes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,50 @@
 # Contributing
 
-## Where to start
+Thanks for contributing — this project only works if it stays easy to run and easy to review.
 
-- For ideas and “what should we build next?”, use Discussions.
-- For bugs or scoped work, use Issues.
-- For code changes, open a PR and link the Issue/Discussion.
+## Quick start
+
+1) Pick a tool folder under `tools/<toolSlug>/`
+2) Run it locally:
+
+```bash
+node scripts/pb/run.mjs recover
+```
+
+3) Make a small improvement
+4) Open a PR
+
+Docs:
+- First contribution: `docs/GETTING_STARTED.md`
+- Self-host quickstart: `docs/SELF_HOST.md`
+- How to add tool #51+: `docs/ADDING_A_TOOL.md`
 
 ## Rules (so this stays sane)
 
 - Keep changes small and reviewable.
 - Security basics first (auth/rate limits/safe defaults) before feature growth.
 - Do not commit secrets. PRs that include keys/tokens will be rejected.
+- Prefer safe failures: return `4xx`/`503 <service>_not_configured` rather than `500`.
+
+## Where things go
+
+- Ideas / debates: Discussions
+  - Start here: `https://github.com/100saas/One-Hundred-SaaS/discussions/1`
+- Bug reports / scoped work: Issues
+- Code changes: PRs (link the Issue/Discussion)
+
+## Labels
+
+If you open an Issue, label it if you can:
+- `type:*` (`type:bug`, `type:feature`, `type:docs`, …)
+- `tool:<slug>` (or propose a new tool)
+- `priority:p0|p1|p2`
+- `status:triage`
+
+Maintainers use:
+- `good first issue` for easy starter tasks
+- `help wanted` for bigger items
 
 ## Licensing
 
 By contributing, you agree your contributions are licensed under this repository’s license.
-


### PR DESCRIPTION
Improves the contributor onboarding flow:

- Expands `CONTRIBUTING.md` with a real quickstart + label guidance
- Adds `tool_request` issue template
- Disables blank issues and routes people to Discussions
- PR template reminder when adding a new tool
