### PR TITLE
Docs: endpoints index + share guide + CI badge

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [100saas]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repo is the public monorepo for the **100saas tool suite**.
 
+[![CI](https://github.com/100saas/One-Hundred-SaaS/actions/workflows/ci.yml/badge.svg)](https://github.com/100saas/One-Hundred-SaaS/actions/workflows/ci.yml)
+
 ## What this is
 
 - A growing set of small, practical tools that replace pricey single‑purpose SaaS.
@@ -24,6 +26,7 @@ This repo is the public monorepo for the **100saas tool suite**.
 - Roadmap: `docs/ROADMAP.md`
 - FAQ: `docs/FAQ.md`
 - Maintainers/triage: `docs/TRIAGE.md`
+- Endpoints index: `docs/ENDPOINTS.md`
 
 ## Why PocketBase (for now)
 

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -1,0 +1,739 @@
+# Endpoints index
+
+This file is auto-generated from `tools/*/pocketbase/pb_hooks/main.pb.js`.
+
+Regenerate:
+
+```bash
+node scripts/generate_endpoints_index.mjs
+```
+
+## access
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/access/cycle/:id/import_csv` |
+| `POST` | `/api/access/cycle/:id/snapshot_internal` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## action
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/action/demo/seed` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## approve
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/approve/public/annotations` |
+| `GET` | `/api/approve/public/project` |
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/approve/demo/seed` |
+| `POST` | `/api/approve/public/annotate` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## archive
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/invites/list` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/archive/demo/seed` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/invites/accept` |
+| `POST` | `/api/invites/create` |
+| `POST` | `/api/jobs/:id/run` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## audit-links
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/audit-links/demo/seed` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## brief
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/brief/public/brief` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/brief/demo/seed` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## careers
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/careers/site/:slug` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## changes
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/changes/demo/seed` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## churn
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/churn/public/config` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/churn/demo/seed` |
+| `POST` | `/api/churn/public/submit` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## collect
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/collect/public/request` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/collect/demo/seed` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## convert
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/convert/demo/seed` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## dunning
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/dunning/seed` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## env
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/env/mark-rotated/:specId` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## fight
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/invites/list` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/fight/demo/seed` |
+| `POST` | `/api/invites/accept` |
+| `POST` | `/api/invites/create` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## handoff
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/handoff/public/package` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/handoff/demo/seed` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/track-download/:id` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## help
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/help/public/article` |
+| `GET` | `/api/help/public/kb` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/help/demo/seed` |
+| `POST` | `/api/kb/article/:id/view` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## hire
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/hire/jobs/:tenantSlug` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## index
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/index/demo/seed` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## log
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/ingest` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## mrr
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/mrr/demo/seed` |
+| `POST` | `/api/mrr/run_once` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## nps
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/nps/demo/seed` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## offer
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/offer/send` |
+| `POST` | `/api/offer/sign/:token` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## onboard
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/onboard/public/progress` |
+| `GET` | `/api/onboard/public/template` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboard/demo/seed` |
+| `POST` | `/api/onboard/public/progress` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## pay
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/pay/contractor/invoices` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/pay/contractors/create` |
+| `POST` | `/api/pay/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## portal
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/portal/public/client` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/portal/demo/seed` |
+| `POST` | `/api/portal/public/item/toggle` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## postmortem
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/postmortem/report/:id` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## press
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/press/kits/:slug` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## proposal
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/proposal/public/view` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/proposal/:id/view` |
+| `POST` | `/api/proposal/demo/seed` |
+| `POST` | `/api/proposal/public/accept` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## qa
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/qa/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## recover
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/invites/list` |
+| `GET` | `/api/recover/rules` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/invites/accept` |
+| `POST` | `/api/invites/create` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/recover/demo/seed` |
+| `POST` | `/api/recover/rules` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## ref
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/ref/request` |
+| `POST` | `/api/ref/respond/:token` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## refunds
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/refunds/settings` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/refunds/demo/seed` |
+| `POST` | `/api/refunds/settings` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## retainer
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/retainer/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## reviews
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/reviews/public/campaign` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/reviews/demo/seed` |
+| `POST` | `/api/reviews/submit` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## route
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/ingest/:apiKey` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## runbook
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/run/:id/checklist` |
+| `POST` | `/api/runbook/:id/start` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## score
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/_debug/score/candidate/:id` |
+| `GET` | `/api/score/summary/:candidateId` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/webhooks/revenuecat` |
+
+## signoff
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/signoff/public/deliverable` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/signoff/demo/seed` |
+| `POST` | `/api/signoff/public/approve` |
+| `POST` | `/api/signoff/public/request_changes` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## sop
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/sop/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## spy
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/spy/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## status
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/status/public/page` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/status/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## subaudit
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/subaudit/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## ticket
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/ticket/public/form` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/ticket/demo/seed` |
+| `POST` | `/api/ticket/public/submit` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## timeline
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/timeline/stripe/customer/:id/summary` |
+| `GET` | `/api/timeline/stripe/customers/search` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/timeline/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## tours
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `GET` | `/api/tours/public/tour` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/tours/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## update
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `GET` | `/api/update/public/feed` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/update/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## uptime
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/uptime/demo/seed` |
+| `POST` | `/api/uptime/run_once` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## utm
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/utm/demo/seed` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## vat
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `GET` | `/api/vat/settings` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/validate` |
+| `POST` | `/api/vat/demo/seed` |
+| `POST` | `/api/vat/settings` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+
+## vote
+
+| Method | Path |
+|---|---|
+| `GET` | `/api/billing/status` |
+| `GET` | `/api/stripe/connect/callback` |
+| `GET` | `/api/stripe/connect/start` |
+| `GET` | `/api/tool/health` |
+| `POST` | `/api/billing/checkout` |
+| `POST` | `/api/billing/portal` |
+| `POST` | `/api/onboarding/bootstrap` |
+| `POST` | `/api/vote/demo/seed` |
+| `POST` | `/api/vote/public/toggle` |
+| `POST` | `/api/webhooks/revenuecat` |
+| `POST` | `/api/webhooks/stripe/billing` |
+

--- a/docs/SHARE.md
+++ b/docs/SHARE.md
@@ -1,0 +1,30 @@
+# Sharing / recruiting contributors
+
+This is the short version of how to talk about the project.
+
+## The pitch (plain)
+
+We’re building a suite of small tools that replace expensive single‑purpose SaaS.
+
+Everything is built in public:
+- requests are Discussions
+- work is Issues
+- code ships via PRs
+
+PocketBase is the default so contributors can run tools locally quickly.
+
+## Where to send people
+
+- Repo: `https://github.com/100saas/One-Hundred-SaaS`
+- Start here: `https://github.com/100saas/One-Hundred-SaaS/discussions/7`
+- Request a tool: `https://github.com/100saas/One-Hundred-SaaS/discussions/8`
+- Good first issues:
+  - `https://github.com/100saas/One-Hundred-SaaS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`
+
+## What we want help with
+
+- Better tool READMEs (clear problem/solution + examples)
+- Endpoint hardening (avoid 500s)
+- Test/verification improvements
+- New tools (scoped + small)
+

--- a/scripts/generate_endpoints_index.mjs
+++ b/scripts/generate_endpoints_index.mjs
@@ -1,0 +1,94 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const root = process.cwd()
+const toolsDir = path.join(root, 'tools')
+const outPath = path.join(root, 'docs', 'ENDPOINTS.md')
+
+async function exists(p) {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function escapeMd(s) {
+  return String(s || '').replaceAll('|', '\\|')
+}
+
+function parseRoutes(source) {
+  const routes = []
+  // Very simple regex: routerAdd("METHOD", "/path", ...)
+  const re = /routerAdd\(\s*["']([A-Z]+)["']\s*,\s*["']([^"']+)["']/g
+  for (const m of source.matchAll(re)) {
+    routes.push({ method: m[1], path: m[2] })
+  }
+  // Deduplicate
+  const seen = new Set()
+  return routes.filter((r) => {
+    const k = `${r.method} ${r.path}`
+    if (seen.has(k)) return false
+    seen.add(k)
+    return true
+  })
+}
+
+async function listTools() {
+  const items = await fs.readdir(toolsDir, { withFileTypes: true })
+  return items.filter((d) => d.isDirectory()).map((d) => d.name).sort()
+}
+
+async function main() {
+  if (!(await exists(toolsDir))) throw new Error(`Missing tools dir: ${toolsDir}`)
+
+  const slugs = await listTools()
+  const byTool = []
+
+  for (const slug of slugs) {
+    const hooksPath = path.join(toolsDir, slug, 'pocketbase', 'pb_hooks', 'main.pb.js')
+    if (!(await exists(hooksPath))) continue
+    const src = await fs.readFile(hooksPath, 'utf8')
+    const routes = parseRoutes(src)
+    byTool.push({ slug, routes })
+  }
+
+  const lines = []
+  lines.push('# Endpoints index')
+  lines.push('')
+  lines.push('This file is auto-generated from `tools/*/pocketbase/pb_hooks/main.pb.js`.')
+  lines.push('')
+  lines.push('Regenerate:')
+  lines.push('')
+  lines.push('```bash')
+  lines.push('node scripts/generate_endpoints_index.mjs')
+  lines.push('```')
+  lines.push('')
+
+  for (const t of byTool) {
+    lines.push(`## ${t.slug}`)
+    lines.push('')
+    if (!t.routes.length) {
+      lines.push('_No `routerAdd()` routes found in this tool hooks file._')
+      lines.push('')
+      continue
+    }
+    lines.push('| Method | Path |')
+    lines.push('|---|---|')
+    for (const r of t.routes.sort((a, b) => (a.method + a.path).localeCompare(b.method + b.path))) {
+      lines.push(`| \`${escapeMd(r.method)}\` | \`${escapeMd(r.path)}\` |`)
+    }
+    lines.push('')
+  }
+
+  await fs.mkdir(path.dirname(outPath), { recursive: true })
+  await fs.writeFile(outPath, lines.join('\n') + '\n', 'utf8')
+  console.log(`wrote ${path.relative(root, outPath)}`)
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err))
+  process.exit(1)
+})
+

--- a/scripts/verify_repo.mjs
+++ b/scripts/verify_repo.mjs
@@ -46,6 +46,9 @@ async function main() {
   const kernelFile = path.join(root, 'kernel', 'pocketbase', '_shared', 'pb_hooks', '_shared', 'kernel.js')
   await fs.access(toolsDir)
   await fs.access(kernelFile)
+  await fs.access(path.join(root, 'docs', 'ENDPOINTS.md')).catch(() => {
+    throw new Error('Missing docs/ENDPOINTS.md (run node scripts/generate_endpoints_index.mjs)')
+  })
 
   const toolSlugs = (await fs.readdir(toolsDir, { withFileTypes: true }))
     .filter((d) => d.isDirectory())
@@ -59,6 +62,9 @@ async function main() {
     const base = path.join(toolsDir, slug, 'pocketbase')
     await fs.access(path.join(base, 'pb_hooks'))
     await fs.access(path.join(base, 'pb_migrations'))
+    await fs.access(path.join(toolsDir, slug, 'README.md')).catch(() => {
+      throw new Error(`Missing tools/${slug}/README.md`)
+    })
   }
 
   // Shallow secret scan


### PR DESCRIPTION
Adds recruiting-friendly docs + visibility:

- `docs/ENDPOINTS.md` auto-generated from tool hooks
- `scripts/generate_endpoints_index.mjs` to regenerate it
- `docs/SHARE.md` (where to send contributors)
- CI badge in README
- Adds GitHub Sponsors metadata (`.github/FUNDING.yml`)
- `scripts/verify_repo.mjs` now checks endpoints index + tool READMEs exist
