### PR TITLE
Docs: tool catalog + support pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo is the public monorepo for the **100saas tool suite**.
 ## Where to start
 
 - Run a tool locally: `docs/SELF_HOST.md`
+- Tool catalog: `docs/TOOLS.md`
 - First contribution: `docs/GETTING_STARTED.md`
 - How we work in GitHub: `docs/GOVERNANCE.md`
 - Shared backend kernel: `docs/KERNEL.md`

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,14 @@
+# Support
+
+This is a build-in-public repository. The fastest way to get help is to use GitHub:
+
+- Questions / “how do I…?”: Discussions
+  - Start here: `https://github.com/100saas/One-Hundred-SaaS/discussions/7`
+- Tool requests / prioritization: Discussions
+  - What to build next: `https://github.com/100saas/One-Hundred-SaaS/discussions/1`
+  - Tool request format: `https://github.com/100saas/One-Hundred-SaaS/discussions/8`
+- Bugs: Issues
+  - Please include: tool slug, steps to reproduce, expected vs actual, and logs
+
+Security issues: please use `SECURITY.md` (private reporting via GitHub Security Advisories).
+

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -7,6 +7,9 @@ This repo is optimized for building. The fastest path is:
 3) Make a small improvement
 4) Open a PR
 
+Tool index:
+- `docs/TOOLS.md`
+
 ## 10‑minute “hello world” PR
 
 1) Pick any tool, e.g. `recover`
@@ -37,4 +40,3 @@ node scripts/verify_repo.mjs
 ## Where to ask questions
 
 - Discussions: `https://github.com/100saas/One-Hundred-SaaS/discussions`
-

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,70 @@
+# Tools
+
+This is the index of tools in this monorepo. Each tool is a PocketBase-first backend (schema + hooks) that you can run locally and self-host.
+
+Quickstart:
+
+```bash
+node scripts/pb/run.mjs <toolSlug>
+```
+
+See: `docs/SELF_HOST.md`.
+
+| # | Tool | Slug | Folder | Run |
+|---:|---|---|---|---|
+| 2 | Archive.100SaaS (Compliance) | `archive` | [`tools/archive`](../tools/archive) | `node scripts/pb/run.mjs archive` |
+| 3 | Fight.100SaaS (Dispute Manager) | `fight` | [`tools/fight`](../tools/fight) | `node scripts/pb/run.mjs fight` |
+| 4 | Refunds.100SaaS (Anomaly Detection) | `refunds` | [`tools/refunds`](../tools/refunds) | `node scripts/pb/run.mjs refunds` |
+| 5 | Timeline.100SaaS (Single Customer View) | `timeline` | [`tools/timeline`](../tools/timeline) | `node scripts/pb/run.mjs timeline` |
+| 6 | VAT.100SaaS (Compliance) | `vat` | [`tools/vat`](../tools/vat) | `node scripts/pb/run.mjs vat` |
+| 7 | SubAudit.100SaaS (Change Logger) | `subaudit` | [`tools/subaudit`](../tools/subaudit) | `node scripts/pb/run.mjs subaudit` |
+| 8 | MRR.100SaaS (Reporting) | `mrr` | [`tools/mrr`](../tools/mrr) | `node scripts/pb/run.mjs mrr` |
+| 9 | Dunning.100SaaS (Copy & Schedule) | `dunning` | [`tools/dunning`](../tools/dunning) | `node scripts/pb/run.mjs dunning` |
+| 10 | Pay.100SaaS (Contractor Portal) | `pay` | [`tools/pay`](../tools/pay) | `node scripts/pb/run.mjs pay` |
+| 11 | Vote.100SaaS (Feature Board) | `vote` | [`tools/vote`](../tools/vote) | `node scripts/pb/run.mjs vote` |
+| 12 | Changes.100SaaS (Changelog) | `changes` | [`tools/changes`](../tools/changes) | `node scripts/pb/run.mjs changes` |
+| 13 | NPS.100SaaS (Micro-Surveys) | `nps` | [`tools/nps`](../tools/nps) | `node scripts/pb/run.mjs nps` |
+| 14 | Churn.100SaaS (Exit Survey Widget) | `churn` | [`tools/churn`](../tools/churn) | `node scripts/pb/run.mjs churn` |
+| 15 | Onboard.100SaaS (Checklists) | `onboard` | [`tools/onboard`](../tools/onboard) | `node scripts/pb/run.mjs onboard` |
+| 16 | Tours.100SaaS (Product Walkthroughs) | `tours` | [`tools/tours`](../tools/tours) | `node scripts/pb/run.mjs tours` |
+| 17 | Status.100SaaS (Status Page) | `status` | [`tools/status`](../tools/status) | `node scripts/pb/run.mjs status` |
+| 18 | Uptime.100SaaS (Website Monitor) | `uptime` | [`tools/uptime`](../tools/uptime) | `node scripts/pb/run.mjs uptime` |
+| 19 | Ticket.100SaaS (Helpdesk) | `ticket` | [`tools/ticket`](../tools/ticket) | `node scripts/pb/run.mjs ticket` |
+| 20 | Help.100SaaS (Knowledge Base) | `help` | [`tools/help`](../tools/help) | `node scripts/pb/run.mjs help` |
+| 21 | Approve.100SaaS (Design Feedback) | `approve` | [`tools/approve`](../tools/approve) | `node scripts/pb/run.mjs approve` |
+| 22 | Portal.100SaaS (Client Home) | `portal` | [`tools/portal`](../tools/portal) | `node scripts/pb/run.mjs portal` |
+| 23 | SOP.100SaaS (Process Builder) | `sop` | [`tools/sop`](../tools/sop) | `node scripts/pb/run.mjs sop` |
+| 24 | Signoff.100SaaS (Approvals) | `signoff` | [`tools/signoff`](../tools/signoff) | `node scripts/pb/run.mjs signoff` |
+| 25 | Collect.100SaaS (Asset Request) | `collect` | [`tools/collect`](../tools/collect) | `node scripts/pb/run.mjs collect` |
+| 26 | Update.100SaaS (Status Feed) | `update` | [`tools/update`](../tools/update) | `node scripts/pb/run.mjs update` |
+| 27 | Proposal.100SaaS (Proposal Generator) | `proposal` | [`tools/proposal`](../tools/proposal) | `node scripts/pb/run.mjs proposal` |
+| 28 | Action.100SaaS (Meeting Tasks) | `action` | [`tools/action`](../tools/action) | `node scripts/pb/run.mjs action` |
+| 29 | Handoff.100SaaS (Client Handoff Portal) | `handoff` | [`tools/handoff`](../tools/handoff) | `node scripts/pb/run.mjs handoff` |
+| 30 | Retainer.100SaaS (Time Tracking) | `retainer` | [`tools/retainer`](../tools/retainer) | `node scripts/pb/run.mjs retainer` |
+| 31 | UTM.100SaaS (Link Builder) | `utm` | [`tools/utm`](../tools/utm) | `node scripts/pb/run.mjs utm` |
+| 32 | QA.100SaaS (Launch Checklist) | `qa` | [`tools/qa`](../tools/qa) | `node scripts/pb/run.mjs qa` |
+| 33 | Brief.100SaaS (Content Brief Builder) | `brief` | [`tools/brief`](../tools/brief) | `node scripts/pb/run.mjs brief` |
+| 34 | Audit.100SaaS (Link Broken Checker) | `audit-links` | [`tools/audit-links`](../tools/audit-links) | `node scripts/pb/run.mjs audit-links` |
+| 35 | Index.100SaaS (GSC Monitor) | `index` | [`tools/index`](../tools/index) | `node scripts/pb/run.mjs index` |
+| 36 | Reviews.100SaaS (Review Funnel) | `reviews` | [`tools/reviews`](../tools/reviews) | `node scripts/pb/run.mjs reviews` |
+| 37 | Convert.100SaaS (Popup Builder) | `convert` | [`tools/convert`](../tools/convert) | `node scripts/pb/run.mjs convert` |
+| 38 | Spy.100SaaS (Competitor Diff) | `spy` | [`tools/spy`](../tools/spy) | `node scripts/pb/run.mjs spy` |
+| 39 | Press.100SaaS (Media Kit) | `press` | [`tools/press`](../tools/press) | `node scripts/pb/run.mjs press` |
+| 40 | Route.100SaaS (Lead Router) | `route` | [`tools/route`](../tools/route) | `node scripts/pb/run.mjs route` |
+| 41 | Score.100SaaS (Interview Rubric) | `score` | [`tools/score`](../tools/score) | `node scripts/pb/run.mjs score` |
+| 42 | Hire.100SaaS (Mini ATS) | `hire` | [`tools/hire`](../tools/hire) | `node scripts/pb/run.mjs hire` |
+| 43 | Ref.100SaaS (Reference Checks) | `ref` | [`tools/ref`](../tools/ref) | `node scripts/pb/run.mjs ref` |
+| 44 | Careers.100SaaS (Job Board) | `careers` | [`tools/careers`](../tools/careers) | `node scripts/pb/run.mjs careers` |
+| 45 | Offer.100SaaS (Offer Letters) | `offer` | [`tools/offer`](../tools/offer) | `node scripts/pb/run.mjs offer` |
+| 46 | Log.100SaaS (Audit Trail) | `log` | [`tools/log`](../tools/log) | `node scripts/pb/run.mjs log` |
+| 47 | Env.100SaaS (Secrets Hygiene) | `env` | [`tools/env`](../tools/env) | `node scripts/pb/run.mjs env` |
+| 48 | Runbook.100SaaS (Interactive Ops) | `runbook` | [`tools/runbook`](../tools/runbook) | `node scripts/pb/run.mjs runbook` |
+| 49 | Postmortem.100SaaS (Incident Retro) | `postmortem` | [`tools/postmortem`](../tools/postmortem) | `node scripts/pb/run.mjs postmortem` |
+| 50 | Access.100SaaS (User Access Reviews) | `access` | [`tools/access`](../tools/access) | `node scripts/pb/run.mjs access` |
+|  | Recover | `recover` | [`tools/recover`](../tools/recover) | `node scripts/pb/run.mjs recover` |
+
+Related:
+
+- Endpoints index: `docs/ENDPOINTS.md`
+- How to contribute: `docs/GETTING_STARTED.md`
+- How we decide what ships: `docs/GOVERNANCE.md`

--- a/scripts/generate_tools_catalog.mjs
+++ b/scripts/generate_tools_catalog.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const root = process.cwd();
+const toolsDir = path.join(root, "tools");
+const outPath = path.join(root, "docs", "TOOLS.md");
+
+function escapePipe(s) {
+  return String(s).replaceAll("|", "\\|");
+}
+
+async function readFirstLine(p) {
+  const text = await fs.readFile(p, "utf8");
+  return (text.split("\n")[0] || "").trim();
+}
+
+function parseToolReadmeTitle(line, slug) {
+  // Example: "# Recover (Tool 1) — PocketBase instance"
+  // Example: "# Action.100SaaS (Meeting Tasks)"
+  const m = line.match(/^#\s+(.+?)\s+\(Tool\s+(\d+)\)/i);
+  if (m) return { name: m[1].trim(), number: Number(m[2]) };
+  const m2 = line.match(/^#\s+(.+?)\s*$/);
+  return { name: (m2?.[1] || slug).trim(), number: null };
+}
+
+function parseToolNumberFromBody(text) {
+  // Example: "**Tool 28**"
+  const m = text.match(/\*\*\s*Tool\s+(\d+)\s*\*\*/i);
+  if (m) return Number(m[1]);
+  // Example: "Tool 28" (fallback)
+  const m2 = text.match(/^\s*Tool\s+(\d+)\s*$/im);
+  if (m2) return Number(m2[1]);
+  return null;
+}
+
+async function main() {
+  const entries = (await fs.readdir(toolsDir, { withFileTypes: true }))
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+
+  const tools = [];
+  for (const slug of entries) {
+    const readmePath = path.join(toolsDir, slug, "README.md");
+    try {
+      const full = await fs.readFile(readmePath, "utf8");
+      const first = (full.split("\n")[0] || "").trim();
+      const { name } = parseToolReadmeTitle(first, slug);
+      const number = parseToolNumberFromBody(full);
+      tools.push({ slug, name, number });
+    } catch {
+      tools.push({ slug, name: slug, number: null });
+    }
+  }
+
+  tools.sort((a, b) => (a.number ?? 9999) - (b.number ?? 9999) || a.slug.localeCompare(b.slug));
+
+  const lines = [];
+  lines.push("# Tools");
+  lines.push("");
+  lines.push(
+    "This is the index of tools in this monorepo. Each tool is a PocketBase-first backend (schema + hooks) that you can run locally and self-host."
+  );
+  lines.push("");
+  lines.push("Quickstart:");
+  lines.push("");
+  lines.push("```bash");
+  lines.push("node scripts/pb/run.mjs <toolSlug>");
+  lines.push("```");
+  lines.push("");
+  lines.push("See: `docs/SELF_HOST.md`.");
+  lines.push("");
+  lines.push("| # | Tool | Slug | Folder | Run |");
+  lines.push("|---:|---|---|---|---|");
+
+  for (const t of tools) {
+    const n = t.number ?? "";
+    const toolCell = escapePipe(t.name);
+    const slugCell = "`" + escapePipe(t.slug) + "`";
+    const folder = `[\`tools/${t.slug}\`](../tools/${t.slug})`;
+    const run = `\`node scripts/pb/run.mjs ${t.slug}\``;
+    lines.push(`| ${n} | ${toolCell} | ${slugCell} | ${folder} | ${run} |`);
+  }
+
+  lines.push("");
+  lines.push("Related:");
+  lines.push("");
+  lines.push("- Endpoints index: `docs/ENDPOINTS.md`");
+  lines.push("- How to contribute: `docs/GETTING_STARTED.md`");
+  lines.push("- How we decide what ships: `docs/GOVERNANCE.md`");
+  lines.push("");
+
+  await fs.writeFile(outPath, lines.join("\n"), "utf8");
+  console.log(`wrote ${path.relative(root, outPath)}`);
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a generated tool catalog (`docs/TOOLS.md`) + generator script (`node scripts/generate_tools_catalog.mjs`), and a root `SUPPORT.md` to route questions/requests to Discussions. Also links the catalog from README and Getting Started.