### PR TITLE
Docs: onboarding pack (self-host troubleshooting + conventions)

### DIFF
--- a/docs/ADDING_A_TOOL.md
+++ b/docs/ADDING_A_TOOL.md
@@ -28,6 +28,18 @@ This creates:
 - `tools/<slug>/pocketbase/pb_hooks/main.pb.js` (hooks entrypoint)
 - `tools/<slug>/pocketbase/pb_migrations/0001_init_schema.js` (starter migration)
 
+## Tool README convention (for the tool catalog)
+
+`docs/TOOLS.md` is generated from `tools/<slug>/README.md`. To keep the catalog sortable:
+- include `**Tool N**` somewhere near the top of the tool README
+- keep the first line as an H1 (`# ...`)
+
+After adding a tool, update the catalog:
+
+```bash
+node scripts/generate_tools_catalog.mjs
+```
+
 ## Test locally
 
 ```bash
@@ -44,4 +56,3 @@ Create an admin user, then verify:
 - Keep it small (one tool, or one kernel change).
 - Link the Issue/Discussion.
 - Do not commit secrets.
-

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -22,13 +22,19 @@ node scripts/pb/run.mjs recover
 3) Open the Admin UI: `http://127.0.0.1:8090/_/`
 4) Create an admin user
 5) Make a tiny doc fix in `tools/recover/README.md`
-6) Run the repo verifier:
+6) Run the syntax check (quick failure if any hooks/migrations are broken):
+
+```bash
+node scripts/check_js_syntax.mjs
+```
+
+7) Run the repo verifier:
 
 ```bash
 node scripts/verify_repo.mjs
 ```
 
-7) Open a PR
+8) Open a PR
 
 ## What to work on
 

--- a/docs/SELF_HOST.md
+++ b/docs/SELF_HOST.md
@@ -2,6 +2,10 @@
 
 This repo is optimized for **building**. Self-hosting is the fastest way to test your changes.
 
+## What is PocketBase?
+
+PocketBase is a small backend (single binary) that gives you auth + database + API in one place. Learn more at `https://pocketbase.io`.
+
 ## Quickstart (local)
 
 Prereqs:
@@ -30,6 +34,12 @@ The first time, create an admin user in the Admin UI.
   - `pb_hooks/_shared/kernel.js` (shared kernel)
 - Starts PocketBase on port `8090` by default.
 
+## Windows (recommended: WSL2)
+
+Windows should work best through **WSL2**:
+- Install Node 20+ inside your WSL distro.
+- Make sure `curl` and `unzip` are installed inside WSL (not just on Windows).
+
 ## Env vars
 
 Most integrations are optional. If a key is missing, endpoints return a safe `503 <service>_not_configured`.
@@ -48,3 +58,30 @@ Use different ports:
 node scripts/pb/run.mjs recover --port 8090
 node scripts/pb/run.mjs refunds --port 8091
 ```
+
+## Troubleshooting
+
+### “Port already in use”
+
+Run on another port:
+
+```bash
+node scripts/pb/run.mjs recover --port 8091
+```
+
+### “Missing dependency: curl/unzip”
+
+Install dependencies and retry.
+
+- macOS (Homebrew): `brew install curl unzip`
+- Debian/Ubuntu/WSL: `sudo apt-get update && sudo apt-get install -y curl unzip`
+
+### “I don’t see any data / where is it stored?”
+
+The runtime data is created under:
+- `.runtime/<toolSlug>/`
+
+### “I can’t log in”
+
+On first run, you must create an admin user in the Admin UI:
+- `http://127.0.0.1:8090/_/`


### PR DESCRIPTION
- Expands `docs/SELF_HOST.md` with PocketBase explainer, WSL notes, and troubleshooting
- Improves `scripts/pb/run.mjs` missing dependency error hints
- Updates `docs/GETTING_STARTED.md` to include `scripts/check_js_syntax.mjs`
- Documents tool README convention + catalog regeneration in `docs/ADDING_A_TOOL.md`