### PR TITLE
Docs: ship notes template + release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This repo is the public monorepo for the **100saas tool suite**.
 - FAQ: `docs/FAQ.md`
 - Licensing: `docs/LICENSING.md`
 - Maintainers/triage: `docs/TRIAGE.md`
+- Maintainer release checklist: `docs/RELEASE.md`
+- Ship notes template: `docs/SHIP_NOTES.md`
 - Endpoints index: `docs/ENDPOINTS.md`
 
 ## Why PocketBase (for now)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,22 @@
+# Release checklist (maintainers)
+
+This repo ships continuously via PR merges. This checklist keeps releases boring.
+
+## Before merging
+
+- Run checks locally:
+  - `node scripts/check_js_syntax.mjs`
+  - `node scripts/verify_repo.mjs`
+- Verify changes fail safely:
+  - prefer `4xx` for bad input
+  - prefer `503 <service>_not_configured` when optional keys are missing
+- Keep PR scope small (one tool or one kernel change).
+
+## After merging
+
+- If the change affects contributors:
+  - update `docs/` (especially `docs/SELF_HOST.md`)
+  - add/adjust a `good first issue` if a follow-up is needed
+- Post a ship note (weekly or when significant):
+  - `docs/SHIP_NOTES.md`
+

--- a/docs/SHIP_NOTES.md
+++ b/docs/SHIP_NOTES.md
@@ -1,0 +1,38 @@
+# Ship notes (weekly template)
+
+We keep ship notes lightweight. The goal is to:
+- show momentum
+- thank contributors
+- point newcomers to easy next work
+
+## Template
+
+Copy/paste into a GitHub Discussion (or a `SHIP_NOTES/` folder later).
+
+```
+## Ship note — YYYY-MM-DD
+
+### Shipped
+- (PR link) ...
+
+### Fixed
+- (Issue link) ...
+
+### Help wanted
+- (link to “good first issues” query)
+- (link to 1–3 high priority issues)
+
+### Thanks
+- @contributor1
+- @contributor2
+```
+
+## Useful links
+
+- Good first issues:
+  - `https://github.com/100saas/One-Hundred-SaaS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`
+- What to build next:
+  - `https://github.com/100saas/One-Hundred-SaaS/discussions/1`
+- How to contribute:
+  - `https://github.com/100saas/One-Hundred-SaaS/discussions/7`
+

--- a/docs/TRIAGE.md
+++ b/docs/TRIAGE.md
@@ -14,6 +14,22 @@ If it’s unclear, ask for:
 - sample data
 - success criteria (“done means…”)
 
+## How we label issues
+
+- `type:*`
+  - `type:bug` regressions / broken behavior
+  - `type:feature` new behavior
+  - `type:docs` documentation-only changes
+  - `type:chore` refactors / cleanup
+  - `type:security` security-related work (use private reporting for vulns)
+- `tool:<slug>`: scope to a specific tool folder
+- `priority:*`: how urgent it is
+- `status:*`: workflow state
+
+Use these two sparingly:
+- `good first issue`: small + clear + easy to verify
+- `help wanted`: bigger or ambiguous, but worth outside help
+
 ## Good first issues
 
 Use `good first issue` for:
@@ -30,4 +46,3 @@ If it smells like a security issue:
 - do not ask for exploit details in public
 - point them to `SECURITY.md`
 - label `type:security`
-


### PR DESCRIPTION
- Adds `docs/SHIP_NOTES.md` (weekly ship note template)
- Adds `docs/RELEASE.md` (maintainer release checklist)
- Expands `docs/TRIAGE.md` with label usage guidance
- Links these from `README.md`