### PR TITLE
Docs: link latest ship note

### DIFF
--- a/docs/SHARE.md
+++ b/docs/SHARE.md
@@ -18,6 +18,7 @@ PocketBase is the default so contributors can run tools locally quickly.
 - Repo: `https://github.com/100saas/One-Hundred-SaaS`
 - Start here: `https://github.com/100saas/One-Hundred-SaaS/discussions/7`
 - Request a tool: `https://github.com/100saas/One-Hundred-SaaS/discussions/8`
+- Latest ship note: `https://github.com/100saas/One-Hundred-SaaS/discussions/48`
 - Good first issues:
   - `https://github.com/100saas/One-Hundred-SaaS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`
 
@@ -27,4 +28,3 @@ PocketBase is the default so contributors can run tools locally quickly.
 - Endpoint hardening (avoid 500s)
 - Test/verification improvements
 - New tools (scoped + small)
-

--- a/docs/SHIP_NOTES.md
+++ b/docs/SHIP_NOTES.md
@@ -5,6 +5,9 @@ We keep ship notes lightweight. The goal is to:
 - thank contributors
 - point newcomers to easy next work
 
+Latest ship note:
+- `https://github.com/100saas/One-Hundred-SaaS/discussions/48`
+
 ## Template
 
 Copy/paste into a GitHub Discussion (or a `SHIP_NOTES/` folder later).
@@ -35,4 +38,3 @@ Copy/paste into a GitHub Discussion (or a `SHIP_NOTES/` folder later).
   - `https://github.com/100saas/One-Hundred-SaaS/discussions/1`
 - How to contribute:
   - `https://github.com/100saas/One-Hundred-SaaS/discussions/7`
-


### PR DESCRIPTION
Links the latest ship note discussion (#48) from `docs/SHIP_NOTES.md` and `docs/SHARE.md` so newcomers see momentum.