### PR TITLE
Docs: picking a tool + local run FAQ

### DIFF
--- a/docs/SELF_HOST.md
+++ b/docs/SELF_HOST.md
@@ -61,6 +61,14 @@ node scripts/pb/run.mjs refunds --port 8091
 
 ## Troubleshooting
 
+## Local run FAQ
+
+- **Do I need API keys?** Usually no. Most integrations are optional; missing keys should return safe `503 <service>_not_configured`.
+- **How do I reset local data?** Each run writes into `.runtime/<toolSlug>/`. If you want to start fresh, remove that folder and rerun the tool. (We intentionally avoid copy/paste “dangerous delete commands” in docs.)
+- **Can I run multiple tools?** Yes—use different ports (see “Running multiple tools” above).
+- **Where is the PocketBase admin UI?** `http://127.0.0.1:<port>/_/`
+- **Where is the API base?** `http://127.0.0.1:<port>/api/`
+
 ### “Port already in use”
 
 Run on another port:

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -10,6 +10,13 @@ node scripts/pb/run.mjs <toolSlug>
 
 See: `docs/SELF_HOST.md`.
 
+## How do I pick a tool?
+
+Pick something you actually want to run this week. A few easy starting points:
+- Customer feedback: `vote`, `nps`, `churn`
+- Support/docs: `help`, `ticket`
+- Monitoring: `uptime`, `status`
+
 | # | Tool | Slug | Folder | Run |
 |---:|---|---|---|---|
 | 2 | Archive.100SaaS (Compliance) | `archive` | [`tools/archive`](../tools/archive) | `node scripts/pb/run.mjs archive` |

--- a/scripts/pb/run.mjs
+++ b/scripts/pb/run.mjs
@@ -147,6 +147,9 @@ async function main() {
   console.log(`- runtime: ${runtimeRoot}`)
   console.log(`- admin:   http://${host}:${port}/_/`)
   console.log(`- api:     http://${host}:${port}/api/\n`)
+  console.log('Next steps:')
+  console.log('- open the Admin UI and create an admin user (first run)')
+  console.log(`- your local data lives in: ${runtimeRoot}\n`)
 
   const child = spawn(pbPath, ['serve', '--http', `${host}:${port}`], {
     cwd: runtimeRoot,


### PR DESCRIPTION
Implements a few newcomer-friendly improvements:
- `docs/TOOLS.md`: add a short “How do I pick a tool?” section
- `docs/SELF_HOST.md`: add a small Local run FAQ (no dangerous delete commands)
- `scripts/pb/run.mjs`: print concise next-steps after startup

Closes: #30, #31, #32