### PR TITLE
Docs: explain what key tools do (vote/status/uptime/help/ticket)

### DIFF
--- a/tools/help/README.md
+++ b/tools/help/README.md
@@ -2,6 +2,35 @@
 
 **Tool 20**
 
+## What it does
+
+A simple public knowledge base backend:
+- categories (`collections`)
+- articles (`articles`) with markdown body
+- public listing uses `tenant_slug` without making the `tenants` collection public
+
+This is backend-first. You can manage content in PocketBase Admin UI, or build a public KB UI on top of the API.
+
+## Core workflow (MVP)
+
+1) Create a category (`collections`)
+2) Create articles, mark `is_published=true`
+3) Optionally run demo seed to populate starter content
+
+## Data model
+
+See `tools/help/pocketbase/SCHEMA.md`:
+- `collections`
+- `articles`
+
+## API notes
+
+Key routes:
+- `GET /api/tool/health`
+- `POST /api/help/demo/seed` (owner-only)
+
+Full list: `docs/ENDPOINTS.md`.
+
 ## What’s in here
 
 - PocketBase backend (hooks + migrations): `tools/help/pocketbase/`

--- a/tools/status/README.md
+++ b/tools/status/README.md
@@ -2,6 +2,35 @@
 
 **Tool 17**
 
+## What it does
+
+A simple status page backend:
+- define `components` (API, website, etc.)
+- publish `incidents` with short updates
+- expose public listing via `tenant_slug` without making the `tenants` collection public
+
+This is backend-first. You can manage everything in the PocketBase Admin UI, or build a UI on top of the public collections.
+
+## Core workflow (MVP)
+
+1) Create components (API/Website/etc)
+2) Create incidents as you investigate and resolve
+3) Optionally run demo seed to populate example data
+
+## Data model
+
+See `tools/status/pocketbase/SCHEMA.md`:
+- `components`
+- `incidents`
+
+## API notes
+
+Key routes:
+- `GET /api/tool/health`
+- `POST /api/status/demo/seed` (owner-only)
+
+Full list: `docs/ENDPOINTS.md`.
+
 ## What’s in here
 
 - PocketBase backend (hooks + migrations): `tools/status/pocketbase/`

--- a/tools/ticket/README.md
+++ b/tools/ticket/README.md
@@ -2,6 +2,38 @@
 
 **Tool 19**
 
+## What it does
+
+A minimal helpdesk backend:
+- public `forms` define the intake + SLA hours
+- internal `tickets` + `ticket_messages` store the conversation
+- `sla_breach_at` is computed when tickets are created
+
+This is backend-first. You can manage tickets in PocketBase Admin UI, or build a small helpdesk UI on top of the API.
+
+## Core workflow (MVP)
+
+1) Create a form (name + SLA hours)
+2) Accept inbound tickets linked to that form
+3) Agents respond via ticket messages
+4) SLA breach time is tracked on the ticket record
+
+## Data model
+
+See `tools/ticket/pocketbase/SCHEMA.md`:
+- `forms`
+- `tickets`
+- `ticket_messages`
+
+## API notes
+
+Key routes:
+- `GET /api/tool/health`
+- `POST /api/ticket/demo/seed` (owner-only)
+- `GET /api/ticket/public/form` (public)
+
+Full list: `docs/ENDPOINTS.md`.
+
 ## What’s in here
 
 - PocketBase backend (hooks + migrations): `tools/ticket/pocketbase/`

--- a/tools/uptime/README.md
+++ b/tools/uptime/README.md
@@ -2,6 +2,36 @@
 
 **Tool 18**
 
+## What it does
+
+A lightweight website monitor backend:
+- define `monitors` (url + interval)
+- cron checks each monitor with a `HEAD` request
+- records outages in `outage_logs`
+
+This is backend-first. You can manage monitors in PocketBase Admin UI, or build a UI on top of the API.
+
+## Core workflow (MVP)
+
+1) Create a monitor (URL + check interval)
+2) Cron runs and updates status/latency
+3) When a monitor goes down/up, outage logs are opened/closed
+
+## Data model
+
+See `tools/uptime/pocketbase/SCHEMA.md`:
+- `monitors`
+- `outage_logs`
+
+## API notes
+
+Key routes:
+- `GET /api/tool/health`
+
+The scheduled checker logic lives in `tools/uptime/pocketbase/pb_hooks/main.pb.js` (`cronAdd`).
+
+Full list: `docs/ENDPOINTS.md`.
+
 ## What’s in here
 
 - PocketBase backend (hooks + migrations): `tools/uptime/pocketbase/`

--- a/tools/vote/README.md
+++ b/tools/vote/README.md
@@ -2,6 +2,39 @@
 
 **Tool 11**
 
+## What it does
+
+A simple feature board:
+- collect feature requests (“posts”)
+- let users vote (public vote toggle endpoint)
+- track status (`under_review` → `planned` → `in_progress` → `done`)
+
+This is backend-first. You can manage data in the PocketBase Admin UI, or build a small UI on top of the API.
+
+## Core workflow (MVP)
+
+1) Create a `board` (private or public)
+2) Create `posts` on that board
+3) If the board is public, accept votes via `POST /api/vote/public/toggle`
+4) Change post status as you ship
+
+## Data model
+
+See `tools/vote/pocketbase/SCHEMA.md`:
+- `boards`
+- `posts`
+- `votes`
+
+## API notes
+
+Custom endpoints are implemented in `tools/vote/pocketbase/pb_hooks/main.pb.js`.
+
+Key routes:
+- `GET /api/tool/health`
+- `POST /api/vote/public/toggle`
+
+Full list: `docs/ENDPOINTS.md`.
+
 ## What’s in here
 
 - PocketBase backend (hooks + migrations): `tools/vote/pocketbase/`


### PR DESCRIPTION
Adds clear ‘what it does’ + core workflow + data model + key endpoints to tool READMEs:
- `tools/vote/README.md`
- `tools/status/README.md`
- `tools/uptime/README.md`
- `tools/help/README.md`
- `tools/ticket/README.md`

Closes: #34 #35 #36 #37 #38