### PR TITLE
Docs: define uniform stack (TanStack + PocketBase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repo is the public monorepo for the **100saas tool suite**.
 - Adding a new tool: `docs/ADDING_A_TOOL.md`
 - Roadmap: `docs/ROADMAP.md`
 - FAQ: `docs/FAQ.md`
+- Stack standard: `docs/STACK.md`
 - Licensing: `docs/LICENSING.md`
 - Maintainers/triage: `docs/TRIAGE.md`
 - Maintainer release checklist: `docs/RELEASE.md`

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -43,6 +43,11 @@ node scripts/verify_repo.mjs
 - Endpoint hardening (return 4xx/503, avoid 500s)
 - Better local-run workflow (scripts/docs)
 
+## Stack standard (important)
+
+When adding UI, use the repo’s default stack:
+- `docs/STACK.md`
+
 ## Where to ask questions
 
 - Discussions: `https://github.com/100saas/One-Hundred-SaaS/discussions`

--- a/docs/STACK.md
+++ b/docs/STACK.md
@@ -1,0 +1,32 @@
+# Stack (contribution standard)
+
+This repo is designed to stay **uniform** so contributors can move between tools without re-learning everything.
+
+## Backend (default)
+
+- **PocketBase** (schema + JS hooks)
+- Shared backend lives in `kernel/` and is reused by tools.
+
+## Frontend (default)
+
+We use a **TanStack-first** approach for frontend plumbing:
+- React 18 + TypeScript
+- Vite
+- TailwindCSS
+- shadcn/ui
+- TanStack Query (data fetching)
+- TanStack Router (routing)
+
+If you’re adding UI, keep it consistent with this stack unless a maintainer explicitly approves a deviation.
+
+## What “backend-first” means today
+
+Many tools currently ship backend logic (collections + hooks + custom routes) without a full UI.
+
+That’s intentional:
+- the PocketBase Admin UI is enough to validate behavior early
+- it keeps PRs small and reviewable
+- it makes self-hosting straightforward
+
+UI work is welcome, but please keep it incremental and tool-scoped.
+


### PR DESCRIPTION
Adds `docs/STACK.md` and links it from README + Getting Started. This clarifies the contribution standard: PocketBase backend + TanStack-first frontend (Query/Router) + shadcn/ui.