### PR TITLE
Docs: roadmap explains project fields

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,6 +6,34 @@ We track work in GitHub, not in a separate system.
 
 - `https://github.com/orgs/100saas/projects/1`
 
+This board is the source of truth for:
+- backlog (what we want to build)
+- in progress (what’s being worked on)
+- roadmap targets (rough dates)
+
+## How to navigate
+
+1) Start with the Project board (Board view).
+2) Open an Epic (issues titled `Epic: ...`) to see what we’re building in that area.
+3) Pick an issue labeled `good first issue` or `help wanted`.
+
+Useful queries:
+- Epics: `https://github.com/100saas/One-Hundred-SaaS/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+Epic%3A`
+- Good first issues: `https://github.com/100saas/One-Hundred-SaaS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`
+
+## Project fields (what they mean)
+
+- `Status`: Backlog/Todo/In Progress/Blocked/Review/Done (kanban)
+- `Priority`: P0/P1/P2 (rough urgency)
+- `Work Type`: Epic/Feature/Bug/Docs/Chore
+- `Batch`: Kernel, Frontend, or Batch ranges (1–3, 4–8, ...)
+- `Target`: a rough date (best-effort; not a promise)
+
+## Stack standard (important)
+
+We keep a uniform stack so contributors can move between tools quickly:
+- `docs/STACK.md`
+
 ## “What should we build next?”
 
 Start here:
@@ -15,4 +43,3 @@ When an idea is clear and scoped, turn it into an Issue and label it:
 - `type:feature`
 - `tool:<slug>` (or propose a new tool)
 - `priority:p0|p1|p2`
-


### PR DESCRIPTION
Updates `docs/ROADMAP.md` to explain how to use the GitHub Project board (kanban), what each custom field means (Priority/Work Type/Batch/Target), and links to Epics + good-first issues.